### PR TITLE
Fix Vercel build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.3.3
 Flask-SQLAlchemy==3.0.5
 Werkzeug==2.3.7
-psycopg2-binary==2.9.7
+psycopg2-binary==2.9.9
 gunicorn==21.2.0
 python-dotenv==1.0.0

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,10 @@
     "builds": [
         {
             "src": "app.py",
-            "use": "@vercel/python"
+            "use": "@vercel/python",
+            "config": {
+                "runtime": "python3.11"
+            }
         }
     ],
     "routes": [


### PR DESCRIPTION
## Summary
- pin Python runtime used by Vercel to Python 3.11
- update psycopg2-binary to 2.9.9

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68494b7fcf5c8322a08b55bda4b39201