### PR TITLE
Fix database initialization and add missing error templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,6 +75,19 @@ class GoToMarketStrategy(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     # Removed updated_at column to avoid database conflict
 
+# Create tables and default admin user if needed
+with app.app_context():
+    db.create_all()
+    if not User.query.filter_by(username='admin').first():
+        admin = User(
+            username='admin',
+            email='admin@skilltrain.com',
+            password_hash=generate_password_hash('admin123'),
+            role='admin'
+        )
+        db.session.add(admin)
+        db.session.commit()
+
 # Authentication decorators
 def login_required(f):
     @wraps(f)

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="text-center mt-5">
+    <h1 class="display-4">404 - Page Not Found</h1>
+    <p class="lead">The page you are looking for does not exist.</p>
+    <a href="{{ url_for('dashboard') }}" class="btn btn-primary">Go Home</a>
+</div>
+{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="text-center mt-5">
+    <h1 class="display-4">Oops! Something went wrong.</h1>
+    <p class="lead">An unexpected error occurred.</p>
+    <a href="{{ url_for('dashboard') }}" class="btn btn-primary">Go Home</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create tables and default admin user on startup
- add 404 and 500 error pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499dac64fc8322a4179c9f7ce128cc